### PR TITLE
Revert "Migrate Deployment Env"

### DIFF
--- a/.github/workflows/backend_pr_cd_job.yml
+++ b/.github/workflows/backend_pr_cd_job.yml
@@ -44,5 +44,5 @@ jobs:
           key: ${{ secrets.PRIVATE_KEY }}
           port: ${{ secrets.PORT }}
           script: |
-            cd ~/citadels/backend 
-            sudo MONGO_URI=$MONGO_URI docker-compose up -d --build
+            cd /webApp/backend 
+            sudo docker-compose up -d --build

--- a/.github/workflows/frontend_pr_cd_job.yml
+++ b/.github/workflows/frontend_pr_cd_job.yml
@@ -29,7 +29,7 @@ jobs:
         SSH_PRIVATE_KEY: ${{ secrets.PRIVATE_KEY }}
         REMOTE_HOST: ${{ secrets.HOST }}
         REMOTE_USER: ${{ secrets.USERNAME }}
-        TARGET: ${{ secrets.TARGET_DIR }}
+        TARGET: ${{ secrets.TARGET_DIR }}/frontend
   
     - name: Executing remote ssh commands using ssh key
       uses: appleboy/ssh-action@master

--- a/.github/workflows/frontend_pr_cd_job.yml
+++ b/.github/workflows/frontend_pr_cd_job.yml
@@ -39,7 +39,7 @@ jobs:
         key: ${{ secrets.PRIVATE_KEY }}
         port: ${{ secrets.PORT }}
         script: |
-                cd /webApp/frontend
+                cd ~/citadels/frontend
                 sudo docker stop react-container
                 sudo docker rm react-container
                 sudo docker rmi react-image


### PR DESCRIPTION
Reverts Game-as-a-Service/citadels-game#121 to update frontend deploy path
